### PR TITLE
feat: add jsii.Sprintf helper

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,9 @@
 package jsii
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type basicType interface {
 	bool | string | float64 | time.Time
@@ -50,6 +53,12 @@ func Numbers[T numberType](v ...T) *[]*float64 {
 
 // String returns a pointer to the provided string.
 func String(v string) *string { return Ptr(v) }
+
+// Sprintf returns a pointer to a fomratted string (semantics are the same as fmt.Sprintf).
+func Sprintf(format string, a ...interface{}) *string {
+	res := fmt.Sprintf(format, a...)
+	return &res
+}
 
 // Strings returns a pointer to a slice of pointers to all of the provided strings.
 func Strings(v ...string) *[]*string {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -64,6 +64,10 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "Hello", *String("Hello"))
 }
 
+func TestSprintf(t *testing.T) {
+	assert.Equal(t, "formatted: 42", *Sprintf("formatted: %d", 42))
+}
+
 func TestStrings(t *testing.T) {
 	assert.Equal(t, []*string{String("Hello"), String("World")}, *Strings("Hello", "World"))
 }


### PR DESCRIPTION
It's a fairly common practice to compose string values using `fmt.Sprintf`, however in order to use these with `jsii` they need to be stored into a variable so a pointer can be taken from them, or they need passed into the `jsii.String` function.

This new helper removes this constraint and provides a simple way to perform `jsii`-friendly string interpolation.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
